### PR TITLE
Fix warning about case-sensitivity of "targetversion" in A18 

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -2,7 +2,7 @@
 <ModMetaData>
 	<name>WM Smarter food selection</name>
 	<author>Wishmaster</author>
-	<targetversion>0.17.1546</targetversion>
+	<targetVersion>0.17.1546</targetVersion>
 	<description>
 &lt;size=18&gt;&lt;color=orange&gt;&lt;b&gt;Requires HugsLib.&lt;/b&gt;&lt;/color&gt;&lt;/size&gt;
 


### PR DESCRIPTION
Using "targetVersion" works in both A17 and A18