### PR TITLE
Fix an obscure bug where a corpse has no edible parts.

### DIFF
--- a/source/FoodScore/FoodScoreUtils.cs
+++ b/source/FoodScore/FoodScoreUtils.cs
@@ -126,7 +126,9 @@ namespace WM.SmarterFoodSelection
 				else if (food.def.IsCorpse)
 				{
 					var corpse = food as Corpse;
-					foodNutrition = RimWorld.FoodUtility.GetBodyPartNutrition(corpse.InnerPawn, corpse.GetBestBodyPartToEat(eater, curFoodLevel));
+					var part = corpse.GetBestBodyPartToEat(eater, curFoodLevel);
+					if (part != null)
+						foodNutrition = RimWorld.FoodUtility.GetBodyPartNutrition(corpse.InnerPawn, part);
 				}
 				else
 					foodNutrition = food.def.ingestible.nutrition;


### PR DESCRIPTION
GetBestBodyPartToEat would select for Outside parts only, with > 0.001f nutrition,

and if there was none, it would return a null BodyPartRecord, and that wasn't checked.

The bug would prevent anyone from eating as they all assess the score on this corpse, and got null exceptioned to death